### PR TITLE
Revert "seal: exclude the trailing slash for dir names"

### DIFF
--- a/seal/seal.sh
+++ b/seal/seal.sh
@@ -224,7 +224,7 @@ parse_lock_args() {
         fi
         ;;
       i )
-        excludes+=("$OPTARG%/") # strip trailing slash
+        excludes+=("$OPTARG")
         ;;
       \? )
         log_error "Invalid option: -$OPTARG"


### PR DESCRIPTION
Reverts ilkermeliksitki/scripts#53

it failed in the tests.

```sh
melik@debian:~$ ./test_seal.sh 
Setting up test sandbox...
---------------------------------------------------
test case: symmetric lock and unlock
---------------------------------------------------
[PASS] Encrypted archive created.
[PASS] Original files removed.
[PASS] .git directory preserved (as requested).
[PASS] File1 restored successfully.
[PASS] Encrypted archive removed after unlock.
---------------------------------------------------
test case: ignore flag (-i)
---------------------------------------------------
[FAIL] Ignored file 'ignore_me.txt' was DELETED!
```